### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/hubot-friends/hubot-service-discovery/security/code-scanning/1](https://github.com/hubot-friends/hubot-service-discovery/security/code-scanning/1)

The best way to fix this problem is to explicitly set the minimal required permissions for the `test` job in the workflow file. Add a `permissions` block under the `test` job, before or after `runs-on`, specifying `contents: read`. This limits the GitHub token to only read contents, which is appropriate for CI jobs that only test or build code and do not need to make any modifications to the repository or interact with issues, pull requests, or other writable resources. No new methods, imports, or additions are required outside of this YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
